### PR TITLE
fix: allow overwriting object extensions at runtime

### DIFF
--- a/src/object.test.ts
+++ b/src/object.test.ts
@@ -1,0 +1,17 @@
+import "./object";
+
+describe("object", () => {
+  it("allows classes to overwrite activesupport property extensions", () => {
+    const methods = ["toEntries", "toValues", "toKeys"];
+    methods.forEach((method) => {
+      class Test {
+        constructor() {
+          this[method] = () => "overwritten";
+        }
+      }
+
+      const test = new Test();
+      expect(test[method]()).toEqual("overwritten");
+    });
+  });
+});

--- a/src/object.test.ts
+++ b/src/object.test.ts
@@ -1,17 +1,28 @@
+import { readFileSync } from "fs";
+import { join } from "path";
 import "./object";
 
 describe("object", () => {
-  it("allows classes to overwrite activesupport property extensions", () => {
-    const methods = ["toEntries", "toValues", "toKeys"];
-    methods.forEach((method) => {
-      class Test {
-        constructor() {
-          this[method] = () => "overwritten";
-        }
-      }
+  const methods = extractObjectExtensions();
 
-      const test = new Test();
-      expect(test[method]()).toEqual("overwritten");
-    });
+  it.each(methods)("allows classes to overwrite activesupport property extension - %s", (method) => {
+    class Test {
+      constructor() {
+        this[method] = () => "overwritten";
+      }
+    }
+
+    const test = new Test();
+    expect(test[method]()).toEqual("overwritten");
   });
 });
+
+function extractObjectExtensions(): string[] {
+  // This is pretty basic right now - if the file becomes more complex, consider using an AST parser.
+  const file = readFileSync(join(__dirname, "object.ts"), "utf8");
+  const methods = [...file.matchAll(/Object\.defineProperty\(Object\.prototype, "(\w+)"/g)].map((match) => match[1]);
+
+  if (methods.length === 0) throw new Error("Could not extract extension methods using regex!");
+
+  return methods;
+}

--- a/src/object.ts
+++ b/src/object.ts
@@ -9,20 +9,29 @@ declare global {
   }
 }
 
+const allowOverwritingPrototypeExtension: PropertyDescriptor = {
+  configurable: true,
+  enumerable: false,
+  writable: true,
+};
+
 Object.defineProperty(Object.prototype, "toEntries", {
   value: function <T>(this: { [s: string]: T } | ArrayLike<T>): [string, T][] {
     return Object.entries(this);
   },
+  ...allowOverwritingPrototypeExtension,
 });
 
 Object.defineProperty(Object.prototype, "toValues", {
   value: function <T>(this: { [s: string]: T } | ArrayLike<T>): T[] {
     return Object.values(this);
   },
+  ...allowOverwritingPrototypeExtension,
 });
 
 Object.defineProperty(Object.prototype, "toKeys", {
   value: function <T>(): string[] {
     return Object.keys(this);
   },
+  ...allowOverwritingPrototypeExtension,
 });


### PR DESCRIPTION
This PR fixes an issue we saw in a private Homebound repo's Storybook:

<img width="440" alt="Screenshot 2023-06-02 at 12 21 00" src="https://github.com/homebound-team/activesupport/assets/630449/ab48e3ff-4289-4760-8328-3c5842949b75">

The issue is that a third-party class declared a `toValues` method. However, because the ActiveSupport extension was not writeable, this error was thrown.

This PR allows folks to overwrite the prototype extension if they choose to.