### PR TITLE
feat(array): unanimous

### DIFF
--- a/src/array.test.ts
+++ b/src/array.test.ts
@@ -128,9 +128,54 @@ describe("array", () => {
 
     it("returns true for empty array", () => {
       // given an empty array
-      const a = [];
+      const a: void[] = [];
       // then it's unanimously silent
       expect(a.unanimous((el) => el)).toBe(true);
+    });
+
+    // This is different than "Your array had an undefined, so I passed it to you," as this
+    // checks that it doesn't internally destructure `const [nullish] = []` to create an
+    // undefined object to pass to fn.
+    it("doesn't call fn with no element", () => {
+      // given an empty array
+      const a: void[] = [];
+      const fn = jest.fn();
+      // when `unanimous` is called
+      a.unanimous(fn);
+      // then fn never got invoked because there were no elements on which to invoke it
+      expect(fn).not.toHaveBeenCalled();
+    });
+
+    it("doesn't call fn more than 1 extra time", () => {
+      // Given 4 elements all equal 1
+      const a = [1, 1, 1, 1];
+      const fn = jest.fn((e) => e === 1);
+      // When we call `unanimous`
+      a.unanimous(fn);
+      // then we get 4+1 calls
+      expect(fn).toHaveBeenCalledTimes(5);
+    });
+
+    it("returns early if applicable", () => {
+      // Given 4 elements, where an early item does not equal 1
+      const a = [1, 2, 1, 1];
+      const fn = jest.fn((e) => e === 1);
+      // When we call `unanimous`
+      a.unanimous(fn);
+      // then we stopped after 3 calls (first 2 elements + comparator)
+      expect(fn).toHaveBeenCalledTimes(3);
+    });
+
+    it("forces fn to deal with undefined elements if applicable", () => {
+      // given an array with undefined
+      const a = [1, 1, undefined, 1];
+      // then failing to account for the undefined results in a type error (and an inevitable thrown error)
+      expect(() =>
+        a.unanimous((el) =>
+          // @ts-expect-error - `el` should factor for possibly-undefined, i.e. `a?.toExponential()`
+          el.toExponential(),
+        ),
+      ).toThrow();
     });
   });
 });

--- a/src/array.test.ts
+++ b/src/array.test.ts
@@ -97,40 +97,40 @@ describe("array", () => {
     });
   });
 
-  describe("unanimous", () => {
+  describe("everyHasSame", () => {
     it("returns true if all elements match", () => {
       // given everything has the same 'name' property
       const a = [{ name: "Homebound" }, { name: "Homebound" }, { name: "Homebound" }];
-      // then expect them to unanimously match
-      expect(a.unanimous((el) => el.name)).toBe(true);
+      // then expect them to everyHasSamely match
+      expect(a.everyHasSame((el) => el.name)).toBe(true);
     });
 
     it("returns false if elements don't match", () => {
       // given 1 item has a different name
       const a = [{ name: "Homebound" }, { name: "Homebound" }, { name: "Nikki" }];
-      // then expect them NOT to be unanimous
-      expect(a.unanimous((el) => el.name)).toBe(false);
+      // then expect them NOT to be everyHasSame
+      expect(a.everyHasSame((el) => el.name)).toBe(false);
     });
 
     it("works for simple data", () => {
       // given even numbers
       const a = [0, 2, 4, 6, 8];
-      // then a check against each of them is unanimous
-      expect(a.unanimous((el) => el % 2 === 0)).toBe(true);
+      // then a check against each of them is everyHasSame
+      expect(a.everyHasSame((el) => el % 2 === 0)).toBe(true);
     });
 
     it("returns true for arrays-of-1", () => {
       // given 1 item
       const a = [1];
-      // then it is unanimous with itself
-      expect(a.unanimous((el) => el)).toBe(true);
+      // then it is everyHasSame with itself
+      expect(a.everyHasSame((el) => el)).toBe(true);
     });
 
     it("returns true for empty array", () => {
       // given an empty array
       const a: void[] = [];
-      // then it's unanimously silent
-      expect(a.unanimous((el) => el)).toBe(true);
+      // then it's everyHasSamely silent
+      expect(a.everyHasSame((el) => el)).toBe(true);
     });
 
     // This is different than "Your array had an undefined, so I passed it to you," as this
@@ -140,8 +140,8 @@ describe("array", () => {
       // given an empty array
       const a: void[] = [];
       const fn = jest.fn();
-      // when `unanimous` is called
-      a.unanimous(fn);
+      // when `everyHasSame` is called
+      a.everyHasSame(fn);
       // then fn never got invoked because there were no elements on which to invoke it
       expect(fn).not.toHaveBeenCalled();
     });
@@ -150,8 +150,8 @@ describe("array", () => {
       // Given 4 elements all equal 1
       const a = [1, 1, 1, 1];
       const fn = jest.fn((e) => e === 1);
-      // When we call `unanimous`
-      a.unanimous(fn);
+      // When we call `everyHasSame`
+      a.everyHasSame(fn);
       // then we get 4+1 calls
       expect(fn).toHaveBeenCalledTimes(5);
     });
@@ -160,8 +160,8 @@ describe("array", () => {
       // Given 4 elements, where an early item does not equal 1
       const a = [1, 2, 1, 1];
       const fn = jest.fn((e) => e === 1);
-      // When we call `unanimous`
-      a.unanimous(fn);
+      // When we call `everyHasSame`
+      a.everyHasSame(fn);
       // then we stopped after 3 calls (first 2 elements + comparator)
       expect(fn).toHaveBeenCalledTimes(3);
     });
@@ -171,7 +171,7 @@ describe("array", () => {
       const a = [1, 1, undefined, 1];
       // then failing to account for the undefined results in a type error (and an inevitable thrown error)
       expect(() =>
-        a.unanimous((el) =>
+        a.everyHasSame((el) =>
           // @ts-expect-error - `el` should factor for possibly-undefined, i.e. `a?.toExponential()`
           el.toExponential(),
         ),

--- a/src/array.test.ts
+++ b/src/array.test.ts
@@ -96,4 +96,41 @@ describe("array", () => {
       expect(result).toEqual([{ foo: 1, bar: 2 }, { foo: 2 }]);
     });
   });
+
+  describe("unanimous", () => {
+    it("returns true if all elements match", () => {
+      // given everything has the same 'name' property
+      const a = [{ name: "Homebound" }, { name: "Homebound" }, { name: "Homebound" }];
+      // then expect them to unanimously match
+      expect(a.unanimous((el) => el.name)).toBe(true);
+    });
+
+    it("returns false if elements don't match", () => {
+      // given 1 item has a different name
+      const a = [{ name: "Homebound" }, { name: "Homebound" }, { name: "Nikki" }];
+      // then expect them NOT to be unanimous
+      expect(a.unanimous((el) => el.name)).toBe(false);
+    });
+
+    it("works for simple data", () => {
+      // given even numbers
+      const a = [0, 2, 4, 6, 8];
+      // then a check against each of them is unanimous
+      expect(a.unanimous((el) => el % 2 === 0)).toBe(true);
+    });
+
+    it("returns true for arrays-of-1", () => {
+      // given 1 item
+      const a = [1];
+      // then it is unanimous with itself
+      expect(a.unanimous((el) => el)).toBe(true);
+    });
+
+    it("returns true for empty array", () => {
+      // given an empty array
+      const a = [];
+      // then it's unanimously silent
+      expect(a.unanimous((el) => el)).toBe(true);
+    });
+  });
 });

--- a/src/array.ts
+++ b/src/array.ts
@@ -69,7 +69,7 @@ declare global {
      * Compares every element in the array to each other and returns true if they all match `fn(el)` and
      * false otherwise. Shorthand for `array.every((el, _, [first]) => el.some.id === first.some.id)`
      */
-    unanimous(f: (el: T) => unknown): boolean;
+    unanimous(fn: (el: T) => unknown): boolean;
   }
 
   interface ReadonlyArray<T> {
@@ -141,7 +141,7 @@ declare global {
      * Compares every element in the array to each other and returns true if they all match `fn(el)` and
      * false otherwise. Shorthand for `array.every((el, _, [first]) => el.some.id === first.some.id)`
      */
-    unanimous(f: (el: T) => unknown): boolean;
+    unanimous(fn: (el: T) => unknown): boolean;
   }
 }
 
@@ -411,10 +411,9 @@ Array.prototype.count = function <T>(this: T[], f: (el: T, index: number, array:
   return this.reduce((count, ...args) => (f(...args) ? count + 1 : count), 0);
 };
 
-Array.prototype.unanimous = function <T>(this: T[], f: (el: T) => unknown): boolean {
-  const [first, ...rest] = this;
-  const comparator = f(first);
-  return rest.every((el) => f(el) === comparator);
+Array.prototype.unanimous = function <T>(this: T[], fn: (el: T) => unknown): boolean {
+  let cached: unknown;
+  return this.every((el, _, [first]) => fn(el) === (cached ??= fn(first)));
 };
 
 Object.defineProperty(Array.prototype, "isEmpty", {

--- a/src/array.ts
+++ b/src/array.ts
@@ -65,6 +65,10 @@ declare global {
     min(this: number[] | Date[]): T;
     min<R extends number | Date>(this: Array<T>, f: (el: T, index: number, array: Array<T>) => R): R;
     count(f: (el: T, index: number, array: T[]) => boolean): number;
+    /**
+     * Compares every element in the array to each other and returns true if they all match `fn(el)` and
+     * false otherwise. Shorthand for `array.every((el, _, [first]) => el.some.id === first.some.id)`
+     */
     unanimous(f: (el: T) => unknown): boolean;
   }
 
@@ -133,6 +137,10 @@ declare global {
     min(this: readonly number[] | readonly Date[]): T;
     min<R extends number | Date>(f: (el: T, index: number, array: readonly T[]) => R): R;
     count(f: (el: T, index: number, array: readonly T[]) => boolean): number;
+    /**
+     * Compares every element in the array to each other and returns true if they all match `fn(el)` and
+     * false otherwise. Shorthand for `array.every((el, _, [first]) => el.some.id === first.some.id)`
+     */
     unanimous(f: (el: T) => unknown): boolean;
   }
 }

--- a/src/array.ts
+++ b/src/array.ts
@@ -69,7 +69,7 @@ declare global {
      * Compares every element in the array to each other and returns true if they all match `fn(el)` and
      * false otherwise. Shorthand for `array.every((el, _, [first]) => el.some.id === first.some.id)`
      */
-    unanimous(fn: (el: T) => unknown): boolean;
+    everyHasSame(fn: (el: T) => unknown): boolean;
   }
 
   interface ReadonlyArray<T> {
@@ -141,7 +141,7 @@ declare global {
      * Compares every element in the array to each other and returns true if they all match `fn(el)` and
      * false otherwise. Shorthand for `array.every((el, _, [first]) => el.some.id === first.some.id)`
      */
-    unanimous(fn: (el: T) => unknown): boolean;
+    everyHasSame(fn: (el: T) => unknown): boolean;
   }
 }
 
@@ -411,7 +411,7 @@ Array.prototype.count = function <T>(this: T[], f: (el: T, index: number, array:
   return this.reduce((count, ...args) => (f(...args) ? count + 1 : count), 0);
 };
 
-Array.prototype.unanimous = function <T>(this: T[], fn: (el: T) => unknown): boolean {
+Array.prototype.everyHasSame = function <T>(this: T[], fn: (el: T) => unknown): boolean {
   let cached: unknown;
   return this.every((el, _, [first]) => fn(el) === (cached ??= fn(first)));
 };

--- a/src/array.ts
+++ b/src/array.ts
@@ -65,6 +65,7 @@ declare global {
     min(this: number[] | Date[]): T;
     min<R extends number | Date>(this: Array<T>, f: (el: T, index: number, array: Array<T>) => R): R;
     count(f: (el: T, index: number, array: T[]) => boolean): number;
+    unanimous(f: (el: T) => unknown): boolean;
   }
 
   interface ReadonlyArray<T> {
@@ -132,6 +133,7 @@ declare global {
     min(this: readonly number[] | readonly Date[]): T;
     min<R extends number | Date>(f: (el: T, index: number, array: readonly T[]) => R): R;
     count(f: (el: T, index: number, array: readonly T[]) => boolean): number;
+    unanimous(f: (el: T) => unknown): boolean;
   }
 }
 
@@ -399,6 +401,12 @@ Array.prototype.min = function <T, R extends number | Date>(
 
 Array.prototype.count = function <T>(this: T[], f: (el: T, index: number, array: T[]) => boolean): number {
   return this.reduce((count, ...args) => (f(...args) ? count + 1 : count), 0);
+};
+
+Array.prototype.unanimous = function <T>(this: T[], f: (el: T) => unknown): boolean {
+  const [first, ...rest] = this;
+  const comparator = f(first);
+  return rest.every((el) => f(el) === comparator);
 };
 
 Object.defineProperty(Array.prototype, "isEmpty", {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,8 @@
     "moduleResolution": "node",
     "declaration": true,
     "skipLibCheck": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "strict": true
   },
   "exclude": ["dist", "node_modules"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,8 @@
     "declaration": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
-    "strict": true
+    "strict": true,
+    "noImplicitAny": false
   },
   "exclude": ["dist", "node_modules"]
 }


### PR DESCRIPTION
I've been writing several checks of the form...

```js
const thingsMatch = array.every((el, _, [first]) => el.path.to.property === first.path.to.property);
```

lately and I'd like it to just be built-in. 