### PR TITLE
chore: ability to use sort/sortBy/sortByKey on bigint values

### DIFF
--- a/src/array.test.ts
+++ b/src/array.test.ts
@@ -26,6 +26,12 @@ describe("array", () => {
       const foos: { foo: any }[] = [{ foo: {} }, { foo: {} }];
       expect(() => foos.sortByKey("foo")).toThrow("Unsupported sortBy values");
     });
+
+    it("works for bigint fields", () => {
+      // Using `any` here as an easy case for the compiler not being able to catch the error
+      const foos: { foo: bigint }[] = [{ foo: 3n }, { foo: -1n }, { foo: 2n }];
+      expect(foos.sortByKey("foo")).toEqual([{ foo: -1n }, { foo: 2n }, { foo: 3n }]);
+    });
   });
 
   describe("groupByObject", () => {

--- a/src/array.ts
+++ b/src/array.ts
@@ -145,7 +145,7 @@ declare global {
   }
 }
 
-export type Sortable = string | number | Date;
+export type Sortable = string | number | Date | bigint;
 
 function isDefined<T extends any>(param: T | undefined | null): param is T {
   return param !== null && param !== undefined;
@@ -177,6 +177,8 @@ Array.prototype.sortBy = function <T, K extends Sortable>(this: Array<T>, f: (el
       return !av && !bv ? 0 : !av ? 1 : -1;
     } else if (typeof av === "number" && typeof bv === "number") {
       return av - bv;
+    } else if (typeof av === "bigint" && typeof bv === "bigint") {
+      return av < bv ? -1 : av > bv ? 1 : 0;
     } else if (typeof av === "string" && typeof bv === "string") {
       return av.localeCompare(bv);
     } else if (av instanceof Date && bv instanceof Date) {


### PR DESCRIPTION
## SC-42370

Add support for bigint arrays when sorting