### PR TITLE
feat: add business days utils

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,5 +37,8 @@
   "lint-staged": {
     "*.{js,ts,css,md}": "prettier --write",
     "*.{js,ts,tsx}": "eslint --fix"
+  },
+  "dependencies": {
+    "date-fns": "^3.5.0"
   }
 }

--- a/src/businessDaysUtils.test.ts
+++ b/src/businessDaysUtils.test.ts
@@ -1,4 +1,4 @@
-import subBusinessDays, { addBusinessDays } from "./businessDaysUtils";
+import subBusinessDays, { addBusinessDays, differenceInBusinessDays } from "./businessDaysUtils";
 
 describe("businessDaysUtils", () => {
   describe("addBusinessDays", () => {
@@ -242,6 +242,331 @@ describe("businessDaysUtils", () => {
         businessDays: [3, 4, 5, 6, 7],
       });
       expect(block).toThrow(RangeError);
+    });
+  });
+
+  describe("differenceInBusinessDays", () => {
+    it("returns the number of business days between the given dates, excluding weekends", () => {
+      const result = differenceInBusinessDays(new Date(2014, 6 /* Jul */, 18), new Date(2014, 0 /* Jan */, 10));
+      expect(result).toBe(135);
+    });
+
+    it("can handle long ranges", () => {
+      jest.setTimeout(500 /* 500 ms test timeout */);
+
+      const result = differenceInBusinessDays(new Date(15000, 0 /* Jan */, 1), new Date(2014, 0 /* Jan */, 1));
+      expect(result).toBe(3387885);
+    });
+
+    it("the same except given first date falls on a weekend", () => {
+      const result = differenceInBusinessDays(new Date(2019, 6 /* Jul */, 20), new Date(2019, 6 /* Jul */, 18));
+      expect(result).toBe(2);
+    });
+
+    it("the same except given second date falls on a weekend", () => {
+      const result = differenceInBusinessDays(new Date(2019, 6 /* Jul */, 23), new Date(2019, 6 /* Jul */, 20));
+      expect(result).toBe(1);
+    });
+
+    it("the same except both given dates fall on a weekend", () => {
+      const result = differenceInBusinessDays(new Date(2019, 6 /* Jul */, 28), new Date(2019, 6 /* Jul */, 20));
+      expect(result).toBe(5);
+    });
+
+    it("returns a negative number if the time value of the first date is smaller", () => {
+      const result = differenceInBusinessDays(new Date(2014, 0 /* Jan */, 10), new Date(2014, 6 /* Jul */, 20));
+      expect(result).toBe(-135);
+    });
+
+    it("accepts timestamps", () => {
+      const result = differenceInBusinessDays(new Date(2014, 6, 18).getTime(), new Date(2014, 0, 10).getTime());
+      expect(result).toBe(135);
+    });
+
+    describe("businessDays option", function () {
+      it("can include Saturday in businessDays", function () {
+        const result = differenceInBusinessDays(new Date(2022, 0 /* Jan */, 17), new Date(2022, 0 /* Jan */, 7), {
+          businessDays: [1, 2, 3, 4, 5, 6],
+        });
+        expect(result).toBe(8);
+      });
+
+      it("can include Saturday in businessDays given first date falls on a non-businessDay", function () {
+        const result = differenceInBusinessDays(new Date(2022, 0 /* Jan */, 16), new Date(2022, 0 /* Jan */, 7), {
+          businessDays: [1, 2, 3, 4, 5, 6],
+        });
+        expect(result).toBe(8);
+      });
+
+      it("can include Saturday in businessDays given second date falls on a non-businessDay", function () {
+        const result = differenceInBusinessDays(new Date(2022, 0 /* Jan */, 17), new Date(2022, 0 /* Jan */, 9), {
+          businessDays: [1, 2, 3, 4, 5, 6],
+        });
+        expect(result).toBe(6);
+      });
+
+      it("can include Sunday in businessDays", function () {
+        const result = differenceInBusinessDays(new Date(2022, 0 /* Jan */, 17), new Date(2022, 0 /* Jan */, 7), {
+          businessDays: [0, 1, 2, 3, 4, 5],
+        });
+        expect(result).toBe(8);
+      });
+
+      it("can include Saturday and Sunday in businessDays", function () {
+        const result = differenceInBusinessDays(new Date(2022, 0 /* Jan */, 17), new Date(2022, 0 /* Jan */, 7), {
+          businessDays: [0, 1, 2, 3, 4, 5, 6],
+        });
+        expect(result).toBe(10);
+      });
+
+      it("throws RangeError if businessDays contains numbers greater than 6", function () {
+        const block = differenceInBusinessDays.bind(null, new Date(2022, 0, 7), new Date(2022, 0, 14), {
+          businessDays: [3, 4, 5, 6, 7],
+        });
+        expect(block).toThrow(RangeError);
+      });
+    });
+
+    describe("exceptions option", function () {
+      it("can add true exceptions to include days as businessDays", function () {
+        // with businessDays as Mon-Fri
+        const result = differenceInBusinessDays(new Date(2022, 0 /* Jan */, 17), new Date(2022, 0 /* Jan */, 7), {
+          // Adding a Saturday and Sunday as business days
+          exceptions: { "01/08/22": true, "01/09/22": true },
+        });
+        expect(result).toBe(8);
+      });
+
+      it("can add false exceptions to remove days as businessDays", function () {
+        // with businessDays as Mon-Fri
+        const result = differenceInBusinessDays(new Date(2022, 0 /* Jan */, 17), new Date(2022, 0 /* Jan */, 7), {
+          // Removing a Tues and Wed as business days
+          exceptions: { "01/11/22": false, "01/12/22": false },
+        });
+        expect(result).toBe(4);
+      });
+
+      it("can handle true and false exceptions", function () {
+        // with businessDays as Mon-Fri
+        const result = differenceInBusinessDays(new Date(2022, 0 /* Jan */, 17), new Date(2022, 0 /* Jan */, 7), {
+          // Adds a Sat and Sun, removes a Tues and Wed as business days
+          exceptions: {
+            "01/08/22": true,
+            "01/09/22": true,
+            "01/11/22": false,
+            "01/12/22": false,
+          },
+        });
+        expect(result).toBe(6);
+      });
+
+      it("should only add true exceptions that are not already businessDays", function () {
+        // with businessDays as Mon-Fri
+        const result = differenceInBusinessDays(new Date(2022, 0 /* Jan */, 17), new Date(2022, 0 /* Jan */, 7), {
+          // Adding a Sat and Sun as business days, but not Mon and Tues which are already business days
+          exceptions: {
+            "01/08/22": true,
+            "01/09/22": true,
+            "01/10/22": true,
+            "01/11/22": true,
+          },
+        });
+        expect(result).toBe(8);
+      });
+
+      it("should only remove false exceptions that are businessDays", function () {
+        // with businessDays as Mon-Fri
+        const result = differenceInBusinessDays(new Date(2022, 0 /* Jan */, 17), new Date(2022, 0 /* Jan */, 7), {
+          // Removing a Tues and Wed as business days, but not Sat and Sun which are not business days
+          exceptions: {
+            "01/11/22": false,
+            "01/12/22": false,
+            "01/15/22": false,
+            "01/16/22": false,
+          },
+        });
+        expect(result).toBe(4);
+      });
+
+      it("can handle exceptions that fall on both of the argument dates", function () {
+        // with businessDays as Mon-Fri
+        const result = differenceInBusinessDays(
+          // Sunday
+          new Date(2022, 0 /* Jan */, 16),
+          // Saturday
+          new Date(2022, 0 /* Jan */, 8),
+          {
+            // Adds business days
+            exceptions: {
+              "01/08/22": true,
+              "01/09/22": true,
+              "01/16/22": true,
+            },
+          },
+        );
+        expect(result).toBe(7);
+      });
+
+      it("can handle true exceptions that fall on both of the argument dates, with a Sat business day", function () {
+        const result = differenceInBusinessDays(
+          // Sunday
+          new Date(2022, 0 /* Jan */, 16),
+          // Sunday
+          new Date(2022, 0 /* Jan */, 9),
+          {
+            // with businessDays as Mon-Sat
+            businessDays: [1, 2, 3, 4, 5, 6],
+            // Adds two Sundays as business days
+            exceptions: {
+              "01/09/22": true,
+              "01/16/22": true,
+            },
+          },
+        );
+        expect(result).toBe(7);
+      });
+
+      it("can handle an exception that falls on the first date", function () {
+        // with businessDays as Mon-Fri
+        const result = differenceInBusinessDays(
+          // Sunday
+          new Date(2022, 0 /* Jan */, 16),
+          // Saturday
+          new Date(2022, 0 /* Jan */, 8),
+          {
+            exceptions: {
+              // Saturday
+              "01/08/22": true,
+              // Sunday
+              "01/09/22": true,
+            },
+          },
+        );
+        expect(result).toBe(6);
+      });
+
+      it("can handle an exception that falls on the second date", function () {
+        // with businessDays as Mon-Fri
+        const result = differenceInBusinessDays(
+          // Sunday
+          new Date(2022, 0 /* Jan */, 16),
+          // Saturday
+          new Date(2022, 0 /* Jan */, 8),
+          {
+            exceptions: {
+              // Saturday
+              "01/09/22": true,
+              // Sunday
+              "01/16/22": true,
+            },
+          },
+        );
+        expect(result).toBe(6);
+      });
+
+      it("should not add exceptions that are not within the date range", function () {
+        // with businessDays as Mon-Fri
+        const result = differenceInBusinessDays(new Date(2022, 0 /* Jan */, 17), new Date(2022, 0 /* Jan */, 7), {
+          // the first and last date are not within the date range, so they should not be added
+          exceptions: {
+            "01/01/22": true,
+            "01/08/22": true,
+            "01/09/22": true,
+            "01/22/22": true,
+          },
+        });
+        expect(result).toBe(8);
+      });
+
+      it("can handle a large amount of enabled Saturday exceptions", function () {
+        // with businessDays as Mon-Fri
+        const result = differenceInBusinessDays(new Date(2022, 1 /* Feb */, 14), new Date(2022, 0 /* Jan */, 3), {
+          // the first and last date are not within the date range, so they should not be added
+          exceptions: {
+            "01/08/22": true,
+            "01/15/22": true,
+            "01/22/22": true,
+            "01/29/22": true,
+            "02/05/22": true,
+            "02/12/22": true,
+            "02/19/22": true, // extra exception that should not be included
+          },
+        });
+        expect(result).toBe(36);
+      });
+
+      it("can handle false exceptions when calculating a 0 day difference", function () {
+        const result = differenceInBusinessDays(new Date(2018, 0 /* Jan */, 1), new Date(2018, 0 /* Jan */, 1), {
+          businessDays: [0, 1, 2, 3, 4, 5, 6],
+          exceptions: { "01/01/18": false },
+        });
+        expect(result).toBe(0);
+      });
+
+      it("can handle false exceptions when calculating a negative difference", function () {
+        const result = differenceInBusinessDays(new Date(2018, 0 /* Jan */, 1), new Date(2018, 0 /* Jan */, 8), {
+          businessDays: [0, 1, 2, 3, 4, 5, 6],
+          exceptions: { "01/06/18": false, "01/07/18": false },
+        });
+        expect(result).toBe(-5);
+      });
+
+      it("can handle false exceptions when calculating a negative difference across years", function () {
+        const result = differenceInBusinessDays(new Date(2017, 11 /* Nov */, 25), new Date(2018, 0 /* Jan */, 1), {
+          businessDays: [0, 1, 2, 3, 4, 5, 6],
+          exceptions: { "12/30/17": false, "12/31/17": false },
+        });
+        expect(result).toBe(-5);
+      });
+    });
+
+    describe("edge cases", function () {
+      it("the difference is less than a day, but the given dates are in different calendar days", function () {
+        const result = differenceInBusinessDays(
+          new Date(2014, 8 /* Sep */, 5, 0, 0),
+          new Date(2014, 8 /* Sep */, 4, 23, 59),
+        );
+        expect(result).toBe(1);
+      });
+
+      it("the same for the swapped dates", () => {
+        const result = differenceInBusinessDays(
+          new Date(2014, 8 /* Sep */, 4, 23, 59),
+          new Date(2014, 8 /* Sep */, 5, 0, 0),
+        );
+        expect(result).toBe(-1);
+      });
+
+      it("the time values of the given dates are the same", () => {
+        const result = differenceInBusinessDays(
+          new Date(2014, 8 /* Sep */, 5, 0, 0),
+          new Date(2014, 8 /* Sep */, 4, 0, 0),
+        );
+        expect(result).toBe(1);
+      });
+
+      it("the given dates are the same", () => {
+        const result = differenceInBusinessDays(
+          new Date(2014, 8 /* Sep */, 5, 0, 0),
+          new Date(2014, 8 /* Sep */, 5, 0, 0),
+        );
+        expect(result).toBe(0);
+      });
+
+      it("returns NaN if the first date is `Invalid Date`", () => {
+        const result = differenceInBusinessDays(new Date(NaN), new Date(2017, 0 /* Jan */, 1));
+        expect(result).toBeNaN();
+      });
+
+      it("returns NaN if the second date is `Invalid Date`", () => {
+        const result = differenceInBusinessDays(new Date(2017, 0 /* Jan */, 1), new Date(NaN));
+        expect(result).toBeNaN();
+      });
+
+      it("returns NaN if the both dates are `Invalid Date`", () => {
+        const result = differenceInBusinessDays(new Date(NaN), new Date(NaN));
+        expect(result).toBeNaN();
+      });
     });
   });
 });

--- a/src/businessDaysUtils.test.ts
+++ b/src/businessDaysUtils.test.ts
@@ -1,0 +1,247 @@
+import subBusinessDays, { addBusinessDays } from "./businessDaysUtils";
+
+describe("businessDaysUtils", () => {
+  describe("addBusinessDays", () => {
+    describe("can add Saturdays and/or Sundays to working days with the businessDays option", () => {
+      it("given an initial date of Jan 7 and adding 8 days, with businessDay = [1, 2, 3, 4, 5, 6], should return Jan 17, 2022", () => {
+        const result = addBusinessDays(new Date(2022, 0 /* Jan */, 7), 8, {
+          businessDays: [1, 2, 3, 4, 5, 6],
+        });
+        expect(result).toEqual(new Date(2022, 0 /* Jan */, 17));
+      });
+
+      it("given an initial date of Jan 7 and adding 8 days, with businessDay = [0, 1, 2, 3, 4, 5], should return Jan 17, 2022", () => {
+        const result = addBusinessDays(new Date(2022, 0 /* Jan */, 7), 8, {
+          businessDays: [0, 1, 2, 3, 4, 5],
+        });
+        expect(result).toEqual(new Date(2022, 0 /* Jan */, 17));
+      });
+
+      it("given an initial date of Jan 7 and adding 10 days, with businessDay = [0, 1, 2, 3, 4, 5, 6], should return Jan 17, 2022", () => {
+        const result = addBusinessDays(new Date(2022, 0 /* Jan */, 7), 10, {
+          businessDays: [0, 1, 2, 3, 4, 5, 6],
+        });
+        expect(result).toEqual(new Date(2022, 0 /* Jan */, 17));
+      });
+    });
+
+    describe("exceptions", () => {
+      it("handles true exceptions", () => {
+        const result = addBusinessDays(new Date(2022, 0 /* Jan */, 7), 10, {
+          businessDays: [1, 2, 3, 4, 5], // M-F
+          exceptions: { "01/08/22": true, "01/09/22": true },
+        });
+        expect(result).toEqual(new Date(2022, 0 /* Jan */, 19));
+      });
+
+      it("handles false exceptions on Mondays", () => {
+        const result = addBusinessDays(new Date(2022, 0 /* Jan */, 7), 9, {
+          businessDays: [1, 2, 3, 4, 5], // M-F
+          exceptions: { "01/10/22": false, "01/17/22": false },
+        });
+        expect(result).toEqual(new Date(2022, 0 /* Jan */, 24));
+      });
+
+      it("handles false exceptions on Saturdays", () => {
+        const result = addBusinessDays(new Date(2022, 0 /* Jan */, 7), 12, {
+          businessDays: [1, 2, 3, 4, 5, 6], // M-Sat
+          exceptions: { "01/08/22": false, "01/15/22": false },
+        });
+        expect(result).toEqual(new Date(2022, 0 /* Jan */, 24));
+      });
+
+      it("handles a mix of true and false exceptions", () => {
+        const result = addBusinessDays(new Date(2022, 0 /* Jan */, 7), 13, {
+          businessDays: [1, 2, 3, 4, 5, 6], // M-Sat
+          exceptions: {
+            "01/08/22": false, // Sat
+            "01/09/22": true, // Sun
+            "01/10/22": true, // Mon (should be ignored since it's already a working day)
+            "01/15/22": true, // Sat (should be ignored since it's already a working day)
+            "01/16/22": false, // Sun (should be ignored since it's already a non-working day)
+            "01/17/22": false, // Mon
+          },
+        });
+        expect(result).toEqual(new Date(2022, 0 /* Jan */, 24));
+      });
+
+      it("ignores exceptions that are out of range", () => {
+        const result = addBusinessDays(new Date(2022, 0 /* Jan */, 7), 10, {
+          businessDays: [1, 2, 3, 4, 5],
+          exceptions: { "01/01/22": true, "01/09/22": true, "01/30/22": true },
+        });
+        expect(result).toEqual(new Date(2022, 0 /* Jan */, 20));
+      });
+
+      it("moves to the following day when ending on a non-working weekend with a true Saturday exception", () => {
+        const result = addBusinessDays(new Date(2022, 0 /* Jan */, 5), 4, {
+          businessDays: [1, 2, 3, 4, 5], // M-F
+          exceptions: { "01/08/22": true },
+        });
+        expect(result).toEqual(new Date(2022, 0 /* Jan */, 10));
+      });
+
+      it("handles true Sunday exceptions", () => {
+        const result = addBusinessDays(new Date(2022, 0 /* Jan */, 5), 5, {
+          businessDays: [1, 2, 3, 4, 5, 6], // M-Sat
+          exceptions: { "01/09/22": true },
+        });
+        expect(result).toEqual(new Date(2022, 0 /* Jan */, 10));
+      });
+
+      it("ends on a true exception", () => {
+        const result = addBusinessDays(new Date(2022, 0 /* Jan */, 5), 4, {
+          businessDays: [1, 2, 3, 4, 5, 6], // M-Sat
+          exceptions: { "01/09/22": true },
+        });
+        expect(result).toEqual(new Date(2022, 0 /* Jan */, 9));
+      });
+
+      it("should move to following Monday when ending on a false exception", () => {
+        const result = addBusinessDays(new Date(2022, 0 /* Jan */, 7), 5, {
+          businessDays: [1, 2, 3, 4, 5], // M-F
+          exceptions: { "01/14/22": false },
+        });
+        expect(result).toEqual(new Date(2022, 0 /* Jan */, 17));
+      });
+
+      it("starts on a non-working Saturday and ends on a false exception, should move to following Monday", () => {
+        const result = addBusinessDays(new Date(2022, 0 /* Jan */, 8), 5, {
+          businessDays: [1, 2, 3, 4, 5], // M-F
+          exceptions: { "01/14/22": false },
+        });
+        expect(result).toEqual(new Date(2022, 0 /* Jan */, 17));
+      });
+
+      it("starts on a false exception", () => {
+        const result = addBusinessDays(new Date(2022, 0 /* Jan */, 7), 5, {
+          businessDays: [1, 2, 3, 4, 5], // M-F
+          exceptions: { "01/07/22": false },
+        });
+        expect(result).toEqual(new Date(2022, 0 /* Jan */, 14));
+      });
+
+      it("starts on a true exception", () => {
+        const result = addBusinessDays(new Date(2022, 0 /* Jan */, 8), 5, {
+          businessDays: [1, 2, 3, 4, 5], // M-F
+          exceptions: { "01/08/22": true },
+        });
+        expect(result).toEqual(new Date(2022, 0 /* Jan */, 14));
+      });
+
+      it("starts and ends on false exceptions, should move to the following working day", () => {
+        const result = addBusinessDays(new Date(2022, 0 /* Jan */, 8), 6, {
+          businessDays: [1, 2, 3, 4, 5, 6], // M-Sat
+          exceptions: { "01/08/22": false, "01/15/22": false },
+        });
+        expect(result).toEqual(new Date(2022, 0 /* Jan */, 17));
+      });
+
+      it("starts and ends on true exceptions", () => {
+        const result = addBusinessDays(new Date(2022, 0 /* Jan */, 8), 6, {
+          businessDays: [1, 2, 3, 4, 5], // M-F
+          exceptions: { "01/08/22": true, "01/15/22": true },
+        });
+        expect(result).toEqual(new Date(2022, 0 /* Jan */, 15));
+      });
+
+      it("handles a large number of working Saturday exceptions, including some out of range", () => {
+        const result = addBusinessDays(new Date(2022, 0 /* Jan */, 3), 36, {
+          businessDays: [1, 2, 3, 4, 5], // M-F
+          exceptions: {
+            "01/08/22": true,
+            "01/15/22": true,
+            "01/22/22": true,
+            "01/29/22": true,
+            "02/05/22": true,
+            "02/12/22": true,
+            "02/19/22": true, // out of range, not incl
+          },
+        });
+        expect(result).toEqual(new Date(2022, 1 /* Jan */, 14));
+      });
+
+      it("handles a large number of working Saturday exceptions when Sundays are working days", () => {
+        const result = addBusinessDays(new Date(2022, 0 /* Jan */, 3), 40, {
+          businessDays: [0, 1, 2, 3, 4, 5], // Sun-F
+          exceptions: {
+            "01/08/22": true,
+            "01/15/22": true,
+            "01/22/22": true,
+            "01/29/22": true,
+            "02/05/22": true,
+            "02/12/22": true,
+            "02/19/22": true, // out of range, not incl
+          },
+        });
+        expect(result).toEqual(new Date(2022, 1 /* Jan */, 12));
+      });
+
+      it("handles a large number of excluded Saturday exceptions, including some out of range", () => {
+        const result = addBusinessDays(new Date(2022, 0 /* Jan */, 3), 36, {
+          businessDays: [1, 2, 3, 4, 5, 6], // M-Sat
+          exceptions: {
+            "01/08/22": false,
+            "01/15/22": false,
+            "01/22/22": false,
+            "01/29/22": false,
+            "02/05/22": false,
+            "02/12/22": false,
+            "02/19/22": false, // out of range, not incl
+          },
+        });
+        expect(result).toEqual(new Date(2022, 1 /* Jan */, 22));
+      });
+    });
+  });
+
+  describe("subBusinessDays", () => {
+    it("can handle a large number of business days", function () {
+      jest.setTimeout(500);
+
+      const result = subBusinessDays(new Date(15000, 0 /* Jan */, 1), 3387885);
+      expect(result).toEqual(new Date(2014, 0 /* Jan */, 1));
+    });
+
+    describe("exceptions", () => {
+      it("can take in a list of enabling exceptions", () => {
+        const result = subBusinessDays(new Date(2022, 0 /* Jan */, 17), 10, {
+          exceptions: {
+            "01/16/22": true,
+            "01/09/22": true,
+          },
+        });
+        expect(result).toEqual(new Date(2022, 0 /* Jan */, 5));
+      });
+
+      it("can take in a list of disabling exceptions", () => {
+        const result = subBusinessDays(new Date(2022, 0 /* Jan */, 24), 10, {
+          exceptions: {
+            "01/17/22": false,
+            "01/10/22": false,
+          },
+        });
+        expect(result).toEqual(new Date(2022, 0 /* Jan */, 6));
+      });
+
+      it("can account for businessDays and exception options", () => {
+        const result = subBusinessDays(new Date(2022, 0 /* Jan */, 24), 11, {
+          // given businessDays of Mon-Sat
+          businessDays: [1, 2, 3, 4, 5, 6],
+          exceptions: {
+            "01/17/22": false,
+            "01/10/22": false,
+          },
+        });
+        expect(result).toEqual(new Date(2022, 0 /* Jan */, 8));
+      });
+    });
+
+    it("throws RangeError if businessDays contains numbers greater than 6", function () {
+      const block = subBusinessDays.bind(null, new Date(2022, 0, 14), 10, {
+        businessDays: [3, 4, 5, 6, 7],
+      });
+      expect(block).toThrow(RangeError);
+    });
+  });
+});

--- a/src/businessDaysUtils.ts
+++ b/src/businessDaysUtils.ts
@@ -1,0 +1,277 @@
+import { addDays, differenceInCalendarDays, format, isAfter, isBefore, isSameDay, isValid, toDate } from "date-fns";
+/**
+ * @name addBusinessDays
+ * @category Day Helpers
+ * @summary Add the specified number of business days (mon - fri) to the given date.
+ *
+ * @description
+ * Add the specified number of business days (mon - fri) to the given date, ignoring weekends.
+ *
+ * @param {Date|Number} date - the date to be changed
+ * @param {Number} amount - the amount of business days to be added. Positive decimals will be rounded using `Math.floor`, decimals less than zero will be rounded using `Math.ceil`.
+ * @param {Object} [options] - an object with options.
+ * @param {Number[]} [options.businessDays=[1, 2, 3, 4, 5]] - the business days. default is Monday to Friday.
+ * @param {Record<string, boolean>} [options.exceptions={}] - exceptions to the business days. Map of date string (with format "MM/DD/YY") to boolean.
+ * @returns {Date} the new date with the business days added
+ * @throws {TypeError} 2 arguments required
+ *
+ * @example
+ * // Add 10 business days to 1 September 2014:
+ * const result = addBusinessDays(new Date(2014, 8, 1), 10)
+ * //=> Mon Sep 15 2014 00:00:00 (skipped weekend days)
+ */
+export function addBusinessDays(
+  dirtyDate: Date | number,
+  dirtyAmount: number,
+  dirtyOptions?: {
+    businessDays?: number[];
+    exceptions?: Record<string, boolean>;
+  },
+): Date {
+  const options = dirtyOptions || {};
+  const exceptions = options.exceptions || {};
+  const businessDays = options.businessDays || [1, 2, 3, 4, 5];
+
+  // Throw a RangeError if businessDays includes a number greater than 6
+  if (businessDays?.filter((number) => number > 6).length > 0) {
+    throw new RangeError("business days must be between 0 and 6");
+  }
+
+  const initialDate = toDate(dirtyDate);
+
+  const amount = dirtyAmount > 0 ? Math.floor(dirtyAmount) : Math.ceil(dirtyAmount);
+
+  if (isNaN(amount)) return new Date(NaN);
+
+  if (initialDate.toString() === "Invalid Date") {
+    return initialDate;
+  }
+
+  // returns a boolean if the date has an exception
+  // true means the date is a working day
+  // false means the date is not a working day
+  const findException = (date: Date): boolean | undefined => {
+    return exceptions[format(date, "MM/dd/yy")];
+  };
+
+  // returns true if the date is a business day (doesn't account for exceptions)
+  const isBusinessDay = (date: Date): boolean => businessDays.includes(date.getDay());
+
+  // returns true if the date is a working day (accounts for exceptions)
+  const isWorkingDay = (date: Date) => {
+    const isDateIncluded = options.exceptions ? findException(date) : undefined;
+    if (isDateIncluded === false) return false;
+    if (isDateIncluded === true || isBusinessDay(date)) {
+      return true;
+    }
+    return false;
+  };
+
+  const newDate = new Date(initialDate);
+  const sign = amount < 0 ? -1 : 1;
+
+  // start on initial day and continue until we have gone through all the days
+  let dayCounter = Math.abs(amount);
+  while (dayCounter > 0) {
+    newDate.setDate(newDate.getDate() + sign);
+    if (isWorkingDay(newDate)) dayCounter -= 1;
+  }
+
+  // If we land on a non-working date, we add/subtract days accordingly to land on the next business day
+  const reduceIfNonWorkingDay = (date: Date) => {
+    if (!isWorkingDay(date) && amount !== 0) {
+      date.setDate(date.getDate() + sign);
+      reduceIfNonWorkingDay(date);
+    }
+  };
+
+  reduceIfNonWorkingDay(newDate);
+
+  // Restore hours to avoid DST lag
+  newDate.setHours(initialDate.getHours());
+
+  return newDate;
+}
+
+/**
+ * @name subBusinessDays
+ * @category Day Helpers
+ * @summary Substract the specified number of business days (mon - fri) to the given date.
+ *
+ * @description
+ * Substract the specified number of business days (mon - fri) to the given date, ignoring weekends.
+ *
+ * @param {Date|Number} date - the date to be changed
+ * @param {Number} amount - the amount of business days to be subtracted. Positive decimals will be rounded using `Math.floor`, decimals less than zero will be rounded using `Math.ceil`.
+ * @param {Object} [options] - an object with options.
+ * @param {Number[]} [options.businessDays=[1, 2, 3, 4, 5]] - the business days. default is Monday to Friday.
+ * @param {Record<string, boolean>} [options.exceptions={}] - exceptions to the business days. Map of date string (with format "MM/DD/YY") to boolean.
+ * @returns {Date} the new date with the business days subtracted
+ * @throws {TypeError} 2 arguments required
+ * @throws {RangeError} businessDays cannot include numbers greater than 6
+ *
+ * @example
+ * // Substract 10 business days from 1 September 2014:
+ * const result = subBusinessDays(new Date(2014, 8, 1), 10)
+ * //=> Mon Aug 18 2014 00:00:00 (skipped weekend days)
+ */
+export default function subBusinessDays(
+  dirtyDate: Date | number,
+  dirtyAmount: number,
+  dirtyOptions?: {
+    businessDays?: number[];
+    exceptions?: Record<string, boolean>;
+  },
+) {
+  const options = dirtyOptions || {};
+  const businessDays = options.businessDays || [1, 2, 3, 4, 5];
+  const exceptions = options.exceptions || {};
+
+  // Throw a RangeError if businessDays includes a number greater than 6
+  if (businessDays?.filter((number) => number > 6).length > 0) {
+    throw new RangeError("business days must be between 0 and 6");
+  }
+
+  return addBusinessDays(dirtyDate, -dirtyAmount, { businessDays, exceptions });
+}
+
+/**
+ * @name differenceInBusinessDays
+ * @category Day Helpers
+ * @summary Get the number of business days between the given dates.
+ *
+ * @description
+ * Get the number of business day periods between the given dates.
+ * Business days being days that arent in the weekend.
+ * Like `differenceInCalendarDays`, the function removes the times from
+ * the dates before calculating the difference.
+ *
+
+ * @param {Date|Number} dateLeft - the later date
+ * @param {Date|Number} dateRight - the earlier date
+ * @param {Object} [options] - an object with options.
+ * @param {Number[]} [options.businessDays=[1, 2, 3, 4, 5]] - the business days. default is Monday to Friday.
+ * @param {Record<string, boolean>} [options.exceptions={}] - exceptions to the business days. Map of date string (with format "MM/DD/YY") to boolean.
+ * @returns {Number} the number of business days
+ * @throws {TypeError} 2 arguments required
+ * @throws {RangeError} businessDays cannot include numbers greater than 6
+ *
+ * @example
+ * // How many business days are between
+ * // 10 January 2014 and 20 July 2014?
+ * const result = differenceInBusinessDays(
+ *   new Date(2014, 6, 20),
+ *   new Date(2014, 0, 10)
+ * )
+ * //=> 136
+ *
+ * // How many business days are between
+ * // 30 November 2021 and 1 November 2021?
+ * const result = differenceInBusinessDays(
+ *   new Date(2021, 10, 30),
+ *   new Date(2021, 10, 1)
+ * )
+ * //=> 21
+ *
+ * // How many business days are between
+ * // 1 November 2021 and 1 December 2021?
+ * const result = differenceInBusinessDays(
+ *   new Date(2021, 10, 1),
+ *   new Date(2021, 11, 1)
+ * )
+ * //=> -22
+ *
+ * // How many business days are between
+ * // 1 November 2021 and 1 November 2021 ?
+ * const result = differenceInBusinessDays(
+ *   new Date(2021, 10, 1),
+ *   new Date(2021, 10, 1)
+ * )
+ * //=> 0
+ */
+export function differenceInBusinessDays(
+  dirtyDateLeft: Date | number,
+  dirtyDateRight: Date | number,
+  dirtyOptions?: {
+    businessDays?: number[];
+    exceptions?: Record<string, boolean>;
+  },
+): number {
+  const options = dirtyOptions || {};
+  const businessDays = options.businessDays || [1, 2, 3, 4, 5];
+
+  // Throw a RangeError if businessDays includes a number greater than 6
+  if (businessDays?.filter((number) => number > 6).length > 0) {
+    throw new RangeError("business days must be between 0 and 6");
+  }
+
+  const dateLeft = toDate(dirtyDateLeft);
+  const dateRight = toDate(dirtyDateRight);
+  const isHoliday = (date: Date) => !businessDays.includes(date.getDay());
+
+  if (!isValid(dateLeft) || !isValid(dateRight)) return NaN;
+
+  const calendarDifference = differenceInCalendarDays(dateLeft, dateRight);
+  const sign = calendarDifference < 0 ? -1 : 1;
+
+  const isInDateBounds = (date: Date) => {
+    return sign > 0
+      ? isBefore(date, dateLeft) && isAfter(date, dateRight)
+      : isAfter(date, dateLeft) && isBefore(date, dateRight);
+  };
+
+  const weeks = Math.trunc(calendarDifference / 7);
+
+  let result = weeks * businessDays.length;
+  let newDateRight = addDays(dateRight, weeks * 7);
+
+  // the loop below will run at most 6 times to account for the remaining days that don't make up a full week
+  while (!isSameDay(dateLeft, newDateRight)) {
+    // sign is used to account for both negative and positive differences
+    result += isHoliday(newDateRight) ? 0 : sign;
+    newDateRight = addDays(newDateRight, sign);
+  }
+
+  // handle exceptions
+  let exceptionCount = 0;
+  if (options.exceptions) {
+    const exceptionDates = Object.keys(options.exceptions);
+    exceptionDates.forEach((e) => {
+      const date = new Date(e);
+      if (!isValid(date)) return;
+      // if date is within the left and right dates
+      if (isInDateBounds(date)) {
+        if (
+          // if exception is true and date is not a business day
+          options.exceptions![e] === true &&
+          !businessDays.includes(date.getDay())
+        ) {
+          // add a day
+          exceptionCount += sign;
+        } else if (
+          // if exception is false and date is a business day
+          options.exceptions![e] === false &&
+          businessDays.includes(date.getDay())
+        ) {
+          // subtract a day
+          exceptionCount -= sign;
+        }
+      }
+    });
+    // handle exceptions for dateLeft and dateRight
+    // if both are true, add one; if both are false, add two; do nothing in all other cases
+    const leftAndRightExceptions = exceptionDates.filter((e) => {
+      const date = new Date(e);
+      return isSameDay(date, dateLeft) || isSameDay(date, dateRight);
+    });
+    if (leftAndRightExceptions.length === 2) {
+      if (leftAndRightExceptions.every((e) => options.exceptions![e] === true)) {
+        exceptionCount++;
+      } else if (leftAndRightExceptions.every((e) => options.exceptions![e] === false)) {
+        exceptionCount--;
+      }
+    }
+  }
+
+  return result + exceptionCount;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2011,6 +2011,7 @@ __metadata:
     "@homebound/eslint-config": ^1.10.0
     "@types/jest": ^29.5.1
     conventional-changelog-conventionalcommits: ^5.0.0
+    date-fns: ^3.5.0
     eslint: ^8.52.0
     husky: ">=6"
     jest: ^29.5.0
@@ -4847,6 +4848,13 @@ __metadata:
   version: 2.2.2
   resolution: "dataloader@npm:2.2.2"
   checksum: 4dabd247089c29f194e94d5434d504f99156c5c214a03463c20f3f17f40398d7e179edee69a27c16e315519ac8739042a810090087ae26449a0e685156a02c65
+  languageName: node
+  linkType: hard
+
+"date-fns@npm:^3.5.0":
+  version: 3.5.0
+  resolution: "date-fns@npm:3.5.0"
+  checksum: 0f326b72aff0a10b5a7a253d7790462263ee3c79b4283fdbb423c3159017f7ddb7cfd8e509ce94c652825232e9aa84278143f333ddb357bc6b03bd39eebd6f5d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
[Hack Day] Add a series of functions for working with business days, previously kept in the homebound-team/date-fns repo. The aim is to eventually remove this fork / its patches from other Homebound repos. 