### PR TITLE
fix: make min/max non-mutating

### DIFF
--- a/src/array/max.ts
+++ b/src/array/max.ts
@@ -15,8 +15,9 @@ declare global {
 
 Array.prototype.max = function <T, R extends Comparable>(this: ToArray<Comparable> | T[], fn?: CallbackFn<T, R>): R {
   const values = fn ? ((this as T[]).map(fn) as R[]) : (this as R[]);
-  let max = values.shift();
-  for (const value of values) {
+  let max = values.first;
+  for (let i = 1; i < values.length; i++) {
+    const value = values[i];
     if (compare(value, max!) > 0) max = value;
   }
   return max!;

--- a/src/array/min.ts
+++ b/src/array/min.ts
@@ -15,8 +15,9 @@ declare global {
 
 Array.prototype.min = function <T, R extends Comparable>(this: ToArray<Comparable>, fn?: CallbackFn<T, R>): R {
   const values = fn ? ((this as T[]).map(fn) as R[]) : (this as R[]);
-  let min = values.shift();
-  for (const value of values) {
+  let min = values.first;
+  for (let i = 1; i < values.length; i++) {
+    const value = values[i];
     if (compare(value, min!) < 0) min = value;
   }
   return min!;


### PR DESCRIPTION
`min`/`max` shouldn't be mutating the underlying array, but currently are if called without a callback