### PR TITLE
fix: resolved circular dependency issue in Object extension methods

### DIFF
--- a/src/object/index.ts
+++ b/src/object/index.ts
@@ -1,9 +1,3 @@
-export const allowOverwritingPrototypeExtension: PropertyDescriptor = {
-  configurable: true,
-  enumerable: false,
-  writable: true,
-};
-
 import "./toEntries";
 import "./toKeys";
 import "./toValues";

--- a/src/object/toEntries.ts
+++ b/src/object/toEntries.ts
@@ -1,4 +1,4 @@
-import { allowOverwritingPrototypeExtension } from "./index";
+import { allowOverwritingPrototypeExtension } from "./utils";
 
 declare global {
   interface Object {

--- a/src/object/toKeys.ts
+++ b/src/object/toKeys.ts
@@ -1,4 +1,4 @@
-import { allowOverwritingPrototypeExtension } from "./index";
+import { allowOverwritingPrototypeExtension } from "./utils";
 
 declare global {
   interface Object {

--- a/src/object/toValues.ts
+++ b/src/object/toValues.ts
@@ -1,4 +1,4 @@
-import { allowOverwritingPrototypeExtension } from "./index";
+import { allowOverwritingPrototypeExtension } from "./utils";
 
 declare global {
   interface Object {

--- a/src/object/utils.ts
+++ b/src/object/utils.ts
@@ -1,0 +1,5 @@
+export const allowOverwritingPrototypeExtension: PropertyDescriptor = {
+  configurable: true,
+  enumerable: false,
+  writable: true,
+};


### PR DESCRIPTION
When using `swc`, the `allowOverwritingPrototypeExtension` constant was `undefined` at runtime, meaning that nothing which inherited from `Object` (ie, everything) could be fully stubbed by `sinon` since `writable` was then defaulting to `false` after the `defineProperty` call.