### PR TITLE
feat: Add removeAll / withoutAll

### DIFF
--- a/src/array/index.ts
+++ b/src/array/index.ts
@@ -29,12 +29,14 @@ import "./nonEmpty";
 import "./notSameElements";
 import "./partition";
 import "./remove";
+import "./removeAll";
 import "./sentenceJoin";
 import "./sortBy";
 import "./sum";
 import "./toObject";
 import "./unique";
 import "./without";
+import "./withoutAll";
 import "./xor";
 
 export type CallbackFn<T, R = any> = (element: T, index: number, array: T[]) => R;

--- a/src/array/remove.test.ts
+++ b/src/array/remove.test.ts
@@ -18,4 +18,118 @@ describe("remove", () => {
     // Then the array is mutated and the element removed
     expect(a).toEqual(["a", "c", "e"]);
   });
+
+  it("handles removing non-existent elements", () => {
+    // Given an array of strings
+    const a = ["a", "b", "c"];
+    // When we remove a non-existent element
+    a.remove("x");
+    // Then the array remains unchanged
+    expect(a).toEqual(["a", "b", "c"]);
+  });
+
+  it("handles removing from an empty array", () => {
+    // Given an empty array
+    const a: string[] = [];
+    // When we remove an element
+    a.remove("a");
+    // Then the array remains empty
+    expect(a).toEqual([]);
+  });
+
+  it("removes all occurrences of duplicate elements", () => {
+    // Given an array with duplicates
+    const a = ["a", "b", "b", "c", "b"];
+    // When we remove the duplicate element
+    a.remove("b");
+    // Then all occurrences are removed
+    expect(a).toEqual(["a", "c"]);
+  });
+
+  it("removes multiple elements including duplicates", () => {
+    // Given an array with duplicates
+    const a = ["a", "b", "b", "c", "c", "d"];
+    // When we remove multiple elements
+    a.remove("b", "c");
+    // Then all occurrences of both elements are removed
+    expect(a).toEqual(["a", "d"]);
+  });
+
+  it("works with numbers", () => {
+    // Given an array of numbers
+    const a = [1, 2, 3, 4, 5];
+    // When we remove a number
+    a.remove(3);
+    // Then the number is removed
+    expect(a).toEqual([1, 2, 4, 5]);
+  });
+
+  it("works with objects using reference equality", () => {
+    // Given an array of objects
+    const obj1 = { id: 1 };
+    const obj2 = { id: 2 };
+    const obj3 = { id: 3 };
+    const a = [obj1, obj2, obj3];
+    // When we remove an object by reference
+    a.remove(obj2);
+    // Then the object is removed
+    expect(a).toEqual([obj1, obj3]);
+  });
+
+  it("does not remove objects with same properties but different references", () => {
+    // Given an array of objects
+    const obj1 = { id: 1 };
+    const obj2 = { id: 2 };
+    const obj3 = { id: 3 };
+    const a = [obj1, obj2, obj3];
+    // When we try to remove an object with same properties but different reference
+    a.remove({ id: 2 } as any);
+    // Then the original object remains
+    expect(a).toEqual([obj1, obj2, obj3]);
+  });
+
+  it("handles removing with no arguments", () => {
+    // Given an array
+    const a = ["a", "b", "c"];
+    // When we call remove with no arguments
+    a.remove();
+    // Then the array remains unchanged
+    expect(a).toEqual(["a", "b", "c"]);
+  });
+
+  it("removes all elements when all are specified", () => {
+    // Given an array
+    const a = ["a", "b", "c"];
+    // When we remove all elements
+    a.remove("a", "b", "c");
+    // Then the array becomes empty
+    expect(a).toEqual([]);
+  });
+
+  it("works with mixed types in a union type array", () => {
+    // Given an array of mixed types
+    const a: (string | number)[] = ["a", 1, "b", 2, "c"];
+    // When we remove elements of different types
+    a.remove("b", 2);
+    // Then both types are removed correctly
+    expect(a).toEqual(["a", 1, "c"]);
+  });
+
+  it("handles undefined and null values", () => {
+    // Given an array with undefined and null
+    const a = ["a", undefined, "b", null, "c"];
+    // When we remove undefined and null
+    a.remove(undefined, null);
+    // Then they are removed
+    expect(a).toEqual(["a", "b", "c"]);
+  });
+
+  it("preserves array order when removing elements", () => {
+    // Given an array with specific order
+    const a = [1, 5, 2, 8, 3, 9, 4];
+    // When we remove some elements
+    a.remove(2, 8, 9);
+    // Then the remaining elements maintain their relative order
+    expect(a).toEqual([1, 5, 3, 4]);
+  });
 });

--- a/src/array/remove.test.ts
+++ b/src/array/remove.test.ts
@@ -10,7 +10,7 @@ describe("remove", () => {
     expect(a).toEqual(["a", "c"]);
   });
 
-  it("removes multiiple elements from an array", () => {
+  it("removes multiple elements from an array", () => {
     // Given an array of strings
     const a = ["a", "b", "c", "d", "e"];
     // When we remove an element

--- a/src/array/remove.ts
+++ b/src/array/remove.ts
@@ -2,16 +2,21 @@ export {}; // needed for TS to realize this file can be imported
 
 declare global {
   interface Array<T> {
+    /**
+     * Removes `element` by mutating the array.
+     *
+     * See `without` for a non-mutating version.
+     */
     remove(element: T): void;
+    /**
+     * Removes `elements` by mutating the array.
+     *
+     * See `without` for a non-mutating version.
+     */
     remove(...elements: readonly T[]): void;
   }
 }
 
 Array.prototype.remove = function <T>(this: T[], ...elements: readonly T[]) {
-  // start from the end of the array so we don't need to worry about re-ordering
-  for (let index = this.length - 1; index >= 0; index--) {
-    if (elements.includes(this[index])) {
-      this.splice(index, 1);
-    }
-  }
+  this.removeAll(elements);
 };

--- a/src/array/removeAll.test.ts
+++ b/src/array/removeAll.test.ts
@@ -1,0 +1,12 @@
+import "./index";
+
+describe("removeAll", () => {
+  it("removes array from an array", () => {
+    // Given an array of strings
+    const a = ["a", "b", "c", "d", "e"];
+    // When we remove an element
+    a.removeAll(["b", "d"]);
+    // Then the array is mutated and the element removed
+    expect(a).toEqual(["a", "c", "e"]);
+  });
+});

--- a/src/array/removeAll.ts
+++ b/src/array/removeAll.ts
@@ -1,0 +1,22 @@
+export {}; // needed for TS to realize this file can be imported
+
+declare global {
+  interface Array<T> {
+    /**
+     * Removes `elements` by mutating the array.
+     *
+     * See `withoutAll` for a non-mutating version.
+     */
+    removeAll(elements: readonly T[]): void;
+  }
+}
+
+Array.prototype.removeAll = function <T>(this: T[], elements: readonly T[]) {
+  if (elements.length === 0) return;
+  // start from the end of the array so we don't need to worry about re-ordering
+  for (let index = this.length - 1; index >= 0; index--) {
+    if (elements.includes(this[index])) {
+      this.splice(index, 1);
+    }
+  }
+};

--- a/src/array/without.test.ts
+++ b/src/array/without.test.ts
@@ -22,4 +22,26 @@ describe("without", () => {
     // And the new array is changed
     expect(b).toEqual(["a", "c", "e"]);
   });
+
+  it("removes 2d arrays without side-effect", () => {
+    // Given an array of arrays
+    const a = [
+      ["a", "a"],
+      ["b", "b"],
+      ["c", "c"],
+    ];
+    // When we remove an element
+    const b = a.without(a[1]);
+    // Then the original array is unchanged
+    expect(a).toEqual([
+      ["a", "a"],
+      ["b", "b"],
+      ["c", "c"],
+    ]);
+    // And the new array is changed
+    expect(b).toEqual([
+      ["a", "a"],
+      ["c", "c"],
+    ]);
+  });
 });

--- a/src/array/without.ts
+++ b/src/array/without.ts
@@ -2,18 +2,22 @@ export {}; // needed for TS to realize this file can be imported
 
 declare global {
   interface Array<T> {
+    /** Returns a copy without `element` included. */
     without(element: T): Array<T>;
+    /** Returns a copy without `elements` included. */
     without(...elements: readonly T[]): Array<T>;
   }
 
   interface ReadonlyArray<T> {
+    /** Returns a copy without `element` included. */
     without(element: T): Array<T>;
+    /** Returns a copy without `elements` included. */
     without(...elements: readonly T[]): Array<T>;
   }
 }
 
 Array.prototype.without = function <T>(this: T[], ...elements: T[]): Array<T> {
   const result = [...this];
-  result.remove(...elements);
+  result.removeAll(elements);
   return result;
 };

--- a/src/array/withoutAll.test.ts
+++ b/src/array/withoutAll.test.ts
@@ -1,0 +1,14 @@
+import "./index";
+
+describe("withoutAll", () => {
+  it("removes array without side-effect", () => {
+    // Given an array of strings
+    const a = ["a", "b", "c"];
+    // When we remove an element
+    const b = a.withoutAll(["b"]);
+    // Then the original array is unchanged
+    expect(a).toEqual(["a", "b", "c"]);
+    // And the new array is changed
+    expect(b).toEqual(["a", "c"]);
+  });
+});

--- a/src/array/withoutAll.ts
+++ b/src/array/withoutAll.ts
@@ -1,0 +1,19 @@
+export {}; // needed for TS to realize this file can be imported
+
+declare global {
+  interface Array<T> {
+    /** Returns a copy without `elements` included. */
+    withoutAll(elements: readonly T[]): Array<T>;
+  }
+
+  interface ReadonlyArray<T> {
+    /** Returns a copy without `elements` included. */
+    withoutAll(elements: T[]): Array<T>;
+  }
+}
+
+Array.prototype.withoutAll = function <T>(this: T[], elements: T[]): Array<T> {
+  const result = [...this];
+  result.removeAll(elements);
+  return result;
+};


### PR DESCRIPTION
So that callers don't have to use `.remove(...array)` and create an extra copy.

Also removes the `...` spread that can lead to max stack size errors:

https://github.com/joist-orm/joist-orm/pull/1515/files