### PR TITLE
fix:  ignore undefined values in array.max

### DIFF
--- a/src/array/max/max.impl.ts
+++ b/src/array/max/max.impl.ts
@@ -1,5 +1,5 @@
 import { CallbackFn, CallbackFnEither, CallbackFnRO } from "src/array/utils";
-import { Comparable, compare } from "src/utils";
+import { Comparable, compare, isDefined } from "src/utils";
 
 /**
  * Returns the maximum value from an array of comparable elements (numbers, strings, dates, etc.).
@@ -41,7 +41,8 @@ export function max<T, R extends Comparable>(arr: readonly T[], fn?: CallbackFnE
   let max = values[0];
   for (let i = 1; i < values.length; i++) {
     const value = values[i];
-    if (compare(value, max!) > 0) max = value;
+    // compare will sort undefined/null as more than any other value, so we need to ensure they're defined before comparing
+    if (!isDefined(max) || (isDefined(value) && compare(value, max!) > 0)) max = value;
   }
   return max!;
 }

--- a/src/array/max/max.test.ts
+++ b/src/array/max/max.test.ts
@@ -67,4 +67,13 @@ describe("max", () => {
     // Then we get back the largest number
     expect(result).toBe(222);
   });
+
+  it("returns a defined value when undefined is present", () => {
+    // Given an array of numbers and undefined values
+    const a = [undefined, 4, 1, undefined, 2, 3, undefined];
+    // When we call max
+    const result = max(a);
+    // Then we get back the largest number
+    expect(result).toBe(4);
+  });
 });

--- a/src/array/min/min.test.ts
+++ b/src/array/min/min.test.ts
@@ -67,4 +67,13 @@ describe("min", () => {
     // Then we get back the smallest number
     expect(result).toBe(-222);
   });
+
+  it("returns a defined value when undefined is present", () => {
+    // Given an array of numbers and undefined values
+    const a = [undefined, 4, 1, undefined, 2, 3, undefined];
+    // When we call min
+    const result = min(a);
+    // Then we get back the smallest number
+    expect(result).toBe(1);
+  });
 });


### PR DESCRIPTION
discovered this while working on the pricing report